### PR TITLE
Fix error on parsing "&amp;"

### DIFF
--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -6,6 +6,7 @@ import { compile } from "./helpers/markdownProcessor";
 import * as storage from "./storage";
 
 let _dispatch: any;
+const reAmpersand = /&amp;/g;
 export const api: WorkerAPI = {
   // Dispatch action to main thread
   async setDispatch(dispatch: any) {
@@ -18,7 +19,7 @@ export const api: WorkerAPI = {
     raw: string;
     line?: number;
   }): Promise<{ html: string; outline: Array<any> }> {
-    return compile(data.raw, data.line);
+    return compile(data.raw.replace(reAmpersand, "&#38;"), data.line);
   },
   async getLastState(): Promise<AppState> {
     const currentSave = await storage.loadCurrentSave();


### PR DESCRIPTION
&amp;amp; と入力するとエラーになるようです。

- 2c3edca8535acc0ea0d19cd8b37a95988744908f をビルド
- Chrome Version 78.0.3904.70 (Official Build) (64-bit)

![image](https://user-images.githubusercontent.com/515948/67856603-4122bc00-fb58-11e9-89cf-e653eaa2c9a2.png)

(参考:VSCodeの場合)
![image](https://user-images.githubusercontent.com/515948/67856661-657e9880-fb58-11e9-93d2-6ac28dfbf356.png)

(修正後)
![image](https://user-images.githubusercontent.com/515948/67856717-83e49400-fb58-11e9-80c7-d57d8425a2db.png)

このPRでは修正していませんが、&amp;gt; 等でも同様の事象が発生するようです。

