### PR TITLE
Exclude vue code block

### DIFF
--- a/src/main/api/markdownProcessor.worker.ts
+++ b/src/main/api/markdownProcessor.worker.ts
@@ -76,7 +76,7 @@ const defaultProcessor = remark()
   .use(math)
   .use(toc)
   .use(katex)
-  .use(hljs)
+  .use(hljs, { exclude: ["vue"] })
   .use(html)
   .use(frontmatter, ["yaml"])
   .use(buildOutline);


### PR DESCRIPTION
mdbuf cannot render markdown when there is a vue code block.

**Before:**
![b21a757ef4dc9354cdc3da3298e15c1f](https://user-images.githubusercontent.com/14838850/85231997-e4517a00-b436-11ea-9b23-93aa20e1d2b1.gif)

**After:**
![3a5f838a7fd8c19d1f16a87463544e95](https://user-images.githubusercontent.com/14838850/85232001-e9162e00-b436-11ea-9dd8-a546af305c5b.gif)
